### PR TITLE
左键点击->左击，右键点击->右击

### DIFF
--- a/src/main/resources/assets/create/lang/zh_cn.json
+++ b/src/main/resources/assets/create/lang/zh_cn.json
@@ -1419,8 +1419,8 @@
 	"create.boiler.via_one_engine": "通过1个引擎",
 	"create.boiler.via_engines": "通过%1$s个引擎",
 
-	"create.gui.schedule.lmb_edit": "左键点击编辑",
-	"create.gui.schedule.rmb_remove": "右键点击移除",
+	"create.gui.schedule.lmb_edit": "左击编辑",
+	"create.gui.schedule.rmb_remove": "右击移除",
 	"create.gui.schedule.duplicate": "复制",
 	"create.gui.schedule.remove_entry": "移除动作",
 	"create.gui.schedule.add_entry": "添加动作",
@@ -2874,8 +2874,8 @@
 
 	"create.ponder.super_glue.header": "使用强力胶来黏附方块",
 	"create.ponder.super_glue.text_1": "强力胶用于将方块组合成移动装置",
-	"create.ponder.super_glue.text_2": "右键点击两个端点来创建一个新的“胶合”区域",
-	"create.ponder.super_glue.text_3": "手持强力胶左键点击可以移除选区",
+	"create.ponder.super_glue.text_2": "右击两个端点来创建一个新的“胶合”区域",
+	"create.ponder.super_glue.text_3": "手持强力胶左击可以移除选区",
 	"create.ponder.super_glue.text_4": "同一个选区内相邻的方块会互相拉动对方",
 	"create.ponder.super_glue.text_5": "互相重叠的选区会一起移动",
 	"create.ponder.super_glue.text_6": "悬挂在其它方块上的方块通常不需要强力胶",


### PR DESCRIPTION
整个文件里有70处用“右击”表达 left-click，5处用“左击”表达 right-click，所以新翻译里的“左键点击”“右键点击”也许需要改一下...？